### PR TITLE
Build cloud functions in unique directories everytime

### DIFF
--- a/src/functionBuilder/builds/README.txt
+++ b/src/functionBuilder/builds/README.txt
@@ -1,0 +1,1 @@
+All the build files in runtime will be stored in this directory.

--- a/src/functionBuilder/compiler/extensions.ts
+++ b/src/functionBuilder/compiler/extensions.ts
@@ -7,7 +7,9 @@ import { getExtension } from "../../rowyService";
 export const addExtensionLib = async (
   name: string,
   user: admin.auth.UserRecord,
-  streamLogger
+  streamLogger,
+  buildPath,
+  buildFolderTimestamp
 ) => {
   try {
     const extensionResp = await getExtension(name);
@@ -16,18 +18,21 @@ export const addExtensionLib = async (
       name: key,
       version: dependencies[key],
     }));
-    const success = await addPackages(packages, user, streamLogger);
+    const success = await addPackages(packages, user, streamLogger, buildPath);
     if (!success) {
       return false;
     }
     const fs = require("fs");
     const path = require("path");
     fs.writeFileSync(
-      path.resolve(__dirname, `../functions/src/extensions/${name}.ts`),
+      path.resolve(
+        __dirname,
+        `../builds/${buildFolderTimestamp}/src/extensions/${name}.ts`
+      ),
       extension
     );
     await asyncExecute(
-      `cd build/functionBuilder/functions/src/extensions;tsc ${name}.ts`,
+      `cd ${buildPath}/src/extensions;tsc ${name}.ts`,
       commandErrorHandler(
         {
           user,

--- a/src/functionBuilder/compiler/terminal.ts
+++ b/src/functionBuilder/compiler/terminal.ts
@@ -1,17 +1,19 @@
 import admin from "firebase-admin";
 import { commandErrorHandler, logErrorToDB } from "../logger";
 import { asyncExecute } from "../../terminalUtils";
+
 export const addPackages = async (
   packages: { name: string; version?: string }[],
   user: admin.auth.UserRecord,
-  streamLogger
+  streamLogger,
+  buildPath
 ) => {
   const packagesString = packages.reduce((acc, currPackage) => {
     return `${acc} ${currPackage.name}@${currPackage.version ?? "latest"}`;
   }, "");
   if (packagesString.trim().length !== 0) {
     const success = await asyncExecute(
-      `cd build/functionBuilder/functions;yarn add ${packagesString}`,
+      `cd ${buildPath};yarn add ${packagesString}`,
       commandErrorHandler(
         {
           user,

--- a/src/functionBuilder/functions/firebase.json
+++ b/src/functionBuilder/functions/firebase.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "source": "."
+  }
+}

--- a/src/terminalUtils.ts
+++ b/src/terminalUtils.ts
@@ -8,11 +8,20 @@ export function execute(command: string, callback: any) {
   });
 }
 
-export const asyncExecute = async (command: string, callback: any) =>
-  new Promise(async (resolve, reject) => {
+export const asyncExecute = async (
+  command: string,
+  callback: any,
+  streamLogger?
+) => {
+  streamLogger?.info(`Executing: ${command}`);
+  return new Promise(async (resolve, reject) => {
     child.exec(command, async function (error, stdout, stderr) {
       console.log({ error, stdout, stderr });
+      streamLogger?.info(
+        `stdout: ${JSON.stringify({ error, stdout, stderr })}`
+      );
       await callback(error, stdout, stderr);
       resolve(!error);
     });
   });
+};


### PR DESCRIPTION
Issue: the added npm packages in Rowy does not get installed if multiple builds are done in a short period of time.

The instability of the function builder is a result of the reuse of `src/functionBuilder/functions` directory.

This PR changes the build path to `src/functionBuilder/builds/[TIMESTAMP]` where `TIMESTAMP` is the unix timestamp at the time the build is started, so each build is performed in its unique directory. 

This issue is resolved in this way.