### PR TITLE
Feat: Runtime options

### DIFF
--- a/src/functionBuilder/compiler/loader/index.ts
+++ b/src/functionBuilder/compiler/loader/index.ts
@@ -46,12 +46,15 @@ export const getConfigFromTableSchema = async (
       };
     }, {});
 
+    const runtimeOptions = schemaData.runtimeOptions ?? {};
+
     const config: TableConfig = {
       derivativeColumns,
       defaultValueColumns,
       documentSelectColumns,
       fieldTypes,
       extensions,
+      runtimeOptions,
     };
     if (schemaData.searchIndex) {
       config.searchIndex = {
@@ -82,6 +85,7 @@ export const combineConfigs = (configs: any[]) =>
         fieldTypes,
         extensions,
         searchIndex,
+        runtimeOptions,
       } = cur;
       return {
         derivativeColumns: [...acc.derivativeColumns, ...derivativeColumns],
@@ -100,6 +104,7 @@ export const combineConfigs = (configs: any[]) =>
         searchIndices: searchIndex
           ? [...acc.searchIndices, searchIndex]
           : acc.searchIndices,
+        runtimeOptions,
       };
     },
     {
@@ -125,6 +130,7 @@ export const generateFile = async (configData, buildFolderTimestamp) => {
     projectId,
     region,
     searchHost,
+    runtimeOptions,
   } = configData;
   const serializedConfigData = {
     fieldTypes: JSON.stringify(fieldTypes),
@@ -136,6 +142,7 @@ export const generateFile = async (configData, buildFolderTimestamp) => {
     extensionsConfig: serialiseExtension(extensions),
     runtimeOptions: JSON.stringify({
       serviceAccount: `rowy-functions@${projectId}.iam.gserviceaccount.com`,
+      ...runtimeOptions,
     }),
     region: JSON.stringify(region),
     searchHost: JSON.stringify(searchHost),

--- a/src/functionBuilder/compiler/loader/types.ts
+++ b/src/functionBuilder/compiler/loader/types.ts
@@ -29,6 +29,12 @@ export interface IExtension {
   extensionBody: string;
   conditions: string;
 }
+
+export interface IRuntimeOptions {
+  memory?: "128MB" | "256MB" | "512MB" | "1GB" | "2GB" | "4GB" | "8GB";
+  timeoutSeconds?: number;
+}
+
 export type TriggerPathType =
   | "collection"
   | "collectionGroup"
@@ -43,4 +49,5 @@ export interface TableConfig {
     id: string;
     fields: string[];
   };
+  runtimeOptions: IRuntimeOptions;
 }


### PR DESCRIPTION
Runtime options are now a part of the table schema, and it will be able to set from the extensions modal:
![Screen Shot 2022-10-20 at 11 35 01](https://user-images.githubusercontent.com/46192266/197108778-d9950755-153a-4318-b5e5-2fe04000df50.png)
![Screen Shot 2022-10-20 at 11 36 26](https://user-images.githubusercontent.com/46192266/197108834-ae229005-a7cc-4656-94d6-bc310930de91.png)

On deployment:
![Screen Shot 2022-10-20 at 11 33 51](https://user-images.githubusercontent.com/46192266/197108856-5c951873-8f64-45c5-b566-c8a5eb3c3f30.png)