### PR TITLE
fix undefined ref.path in evaluate all

### DIFF
--- a/src/scripts/derivative.ts
+++ b/src/scripts/derivative.ts
@@ -66,7 +66,7 @@ export const evaluateDerivative = async (req: Request, res: Response) => {
     const logging = await LoggingFactory.createDerivativeLogging(
       columnKey,
       schemaDoc.ref.id,
-      ref.path
+      collectionPath ?? ""
     );
 
     const derivativeFunction = eval(


### PR DESCRIPTION
Fixes https://github.com/rowyio/rowy/discussions/1053

`ref` might be undefined thus directly accessing `ref.path` will cause the undefined error for evaluate all. `collectionPath` seem more appropriate in this context.